### PR TITLE
Update FlatPages import in dead-easy-yet-powerful-static-website-generator-with-flask

### DIFF
--- a/pages/code/2012/dead-easy-yet-powerful-static-website-generator-with-flask.md
+++ b/pages/code/2012/dead-easy-yet-powerful-static-website-generator-with-flask.md
@@ -259,7 +259,7 @@ Here enters Frozen-Flask. Its use is damn easy:
     import sys
 
     from flask import Flask, render_template
-    from flaskext.flatpages import FlatPages
+    from flask_flatpages import FlatPages
     from flask_frozen import Freezer
 
     DEBUG = True


### PR DESCRIPTION
For the current version of FlatPages(0.11) you need to import this way. Thanks for the great tutorial!
https://pythonhosted.org/Flask-FlatPages/
